### PR TITLE
Add data source plugin architecture

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/Common/Interfaces/IDataSourceAdapter.cs
+++ b/Common/Interfaces/IDataSourceAdapter.cs
@@ -1,0 +1,11 @@
+namespace Common.Interfaces;
+
+using Common.Models;
+
+public interface IDataSourceAdapter
+{
+    Task<bool> TestConnectionAsync(DataSourceConfig config);
+    Task<Schema?> GetSchemaAsync(DataSourceConfig config, string objectName);
+    Task<List<Dictionary<string, object>>> ReadAsync(string query, DataSourceConfig config);
+    Task<int> WriteAsync(string table, IEnumerable<Dictionary<string, object>> data, DataSourceConfig config);
+}

--- a/Common/Interfaces/IDataSourcePlugin.cs
+++ b/Common/Interfaces/IDataSourcePlugin.cs
@@ -1,0 +1,8 @@
+namespace Common.Interfaces;
+
+public interface IDataSourcePlugin
+{
+    string TypeCode { get; }
+    string TypeName { get; }
+    IDataSourceAdapter CreateAdapter();
+}

--- a/Common/Models/DataSourceConfig.cs
+++ b/Common/Models/DataSourceConfig.cs
@@ -1,0 +1,11 @@
+namespace Common.Models;
+
+public class DataSourceConfig
+{
+    public string? Host { get; set; }
+    public int? Port { get; set; }
+    public string? DbName { get; set; }
+    public string? User { get; set; }
+    public string? Password { get; set; }
+    public string? ExtraJson { get; set; }
+}

--- a/Common/Models/Schema.cs
+++ b/Common/Models/Schema.cs
@@ -1,0 +1,14 @@
+namespace Common.Models;
+
+public class Schema
+{
+    public List<FieldMeta> Fields { get; set; } = new();
+}
+
+public class FieldMeta
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Type { get; set; }
+    public int? Length { get; set; }
+    public bool Nullable { get; set; }
+}

--- a/DataSourceService/DataSourceService.Application/DataSourcePluginManager.cs
+++ b/DataSourceService/DataSourceService.Application/DataSourcePluginManager.cs
@@ -1,0 +1,47 @@
+namespace DataSourceService.Application;
+
+using System.Reflection;
+using Common.Interfaces;
+
+public class DataSourcePluginManager : ITransient
+{
+    private readonly Dictionary<string, IDataSourceAdapter> _adapters = new();
+
+    public void LoadAll()
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "plugins", "datasource");
+        if (!Directory.Exists(dir)) return;
+        foreach (var file in Directory.GetFiles(dir, "*.dll"))
+        {
+            LoadAsync(file).GetAwaiter().GetResult();
+        }
+    }
+
+    public async Task LoadAsync(string pluginPath)
+    {
+        var asm = Assembly.LoadFrom(pluginPath);
+        foreach (var type in asm.GetTypes())
+        {
+            if (typeof(IDataSourcePlugin).IsAssignableFrom(type) && !type.IsAbstract)
+            {
+                if (Activator.CreateInstance(type) is IDataSourcePlugin plugin)
+                {
+                    var adapter = plugin.CreateAdapter();
+                    _adapters[plugin.TypeCode] = adapter;
+                }
+            }
+        }
+        await Task.CompletedTask;
+    }
+
+    public IDataSourceAdapter? GetAdapter(string typeCode)
+    {
+        _adapters.TryGetValue(typeCode, out var adapter);
+        return adapter;
+    }
+
+    public void Unload(string typeCode)
+    {
+        _adapters.Remove(typeCode);
+    }
+}

--- a/DataSourceService/DataSourceService.Application/DataSourceService.Application.csproj
+++ b/DataSourceService/DataSourceService.Application/DataSourceService.Application.csproj
@@ -21,6 +21,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\DataSourceService.Core\DataSourceService.Core.csproj" />
+                <ProjectReference Include="..\..\Common\Common.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DataSourceService/DataSourceService.Application/DataSourceTypes/DataSourceTypeAppService.cs
+++ b/DataSourceService/DataSourceService.Application/DataSourceTypes/DataSourceTypeAppService.cs
@@ -1,0 +1,31 @@
+namespace DataSourceService.Application.DataSourceTypes;
+
+using DataSourceService.Application.DataSourceTypes.Dtos;
+using DataSourceService.Application.DataSourceTypes.Services;
+
+public class DataSourceTypeAppService : IDynamicApiController
+{
+    private readonly IDataSourceTypeService _service;
+    public DataSourceTypeAppService(IDataSourceTypeService service)
+    {
+        _service = service;
+    }
+
+    public Task<List<DataSourceTypeDto>> GetList()
+        => _service.GetListAsync();
+
+    public Task<DataSourceTypeDto?> Get(string code)
+        => _service.GetAsync(code);
+
+    public Task Create(DataSourceTypeDto dto)
+        => _service.CreateAsync(dto);
+
+    public Task Update(DataSourceTypeDto dto)
+        => _service.UpdateAsync(dto);
+
+    public Task Delete(string code)
+        => _service.DeleteAsync(code);
+
+    public Task UploadPlugin([FromForm] IFormFile file)
+        => _service.LoadPluginAsync(file);
+}

--- a/DataSourceService/DataSourceService.Application/DataSourceTypes/Dtos/DataSourceTypeDto.cs
+++ b/DataSourceService/DataSourceService.Application/DataSourceTypes/Dtos/DataSourceTypeDto.cs
@@ -1,0 +1,9 @@
+namespace DataSourceService.Application.DataSourceTypes.Dtos;
+
+public class DataSourceTypeDto
+{
+    public string Code { get; set; } = string.Empty;
+    public string? Name { get; set; }
+    public string? ConfigSchema { get; set; }
+    public string? PluginAssembly { get; set; }
+}

--- a/DataSourceService/DataSourceService.Application/DataSourceTypes/Services/DataSourceTypeService.cs
+++ b/DataSourceService/DataSourceService.Application/DataSourceTypes/Services/DataSourceTypeService.cs
@@ -1,0 +1,60 @@
+namespace DataSourceService.Application.DataSourceTypes.Services;
+
+using Common.Interfaces;
+using DataSourceService.Application.DataSourceTypes.Dtos;
+using DataSourceService.Core.Entities;
+using DataSourceService.Core.Repositories;
+
+public class DataSourceTypeService : IDataSourceTypeService, ITransient
+{
+    private readonly IDataSourceTypeRepo _repo;
+    private readonly DataSourcePluginManager _pluginManager;
+
+    public DataSourceTypeService(IDataSourceTypeRepo repo, DataSourcePluginManager pluginManager)
+    {
+        _repo = repo;
+        _pluginManager = pluginManager;
+    }
+
+    public async Task<List<DataSourceTypeDto>> GetListAsync()
+    {
+        var list = await _repo.GetListAsync();
+        return list.Adapt<List<DataSourceTypeDto>>();
+    }
+
+    public async Task<DataSourceTypeDto?> GetAsync(string code)
+    {
+        var entity = await _repo.GetAsync(code);
+        return entity?.Adapt<DataSourceTypeDto>();
+    }
+
+    public async Task CreateAsync(DataSourceTypeDto dto)
+    {
+        var entity = dto.Adapt<DataSourceType>();
+        await _repo.InsertAsync(entity);
+    }
+
+    public async Task UpdateAsync(DataSourceTypeDto dto)
+    {
+        var entity = dto.Adapt<DataSourceType>();
+        await _repo.UpdateAsync(entity);
+    }
+
+    public async Task DeleteAsync(string code)
+    {
+        await _repo.DeleteAsync(code);
+        _pluginManager.Unload(code);
+    }
+
+    public async Task LoadPluginAsync(IFormFile file)
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "plugins", "datasource");
+        Directory.CreateDirectory(dir);
+        var filePath = Path.Combine(dir, file.FileName);
+        using (var stream = File.Create(filePath))
+        {
+            await file.CopyToAsync(stream);
+        }
+        await _pluginManager.LoadAsync(filePath);
+    }
+}

--- a/DataSourceService/DataSourceService.Application/DataSourceTypes/Services/IDataSourceTypeService.cs
+++ b/DataSourceService/DataSourceService.Application/DataSourceTypes/Services/IDataSourceTypeService.cs
@@ -1,0 +1,13 @@
+namespace DataSourceService.Application.DataSourceTypes.Services;
+
+using DataSourceService.Application.DataSourceTypes.Dtos;
+
+public interface IDataSourceTypeService
+{
+    Task<List<DataSourceTypeDto>> GetListAsync();
+    Task<DataSourceTypeDto?> GetAsync(string code);
+    Task CreateAsync(DataSourceTypeDto dto);
+    Task UpdateAsync(DataSourceTypeDto dto);
+    Task DeleteAsync(string code);
+    Task LoadPluginAsync(IFormFile file);
+}

--- a/DataSourceService/DataSourceService.Application/DataSources/DataSourceAppService.cs
+++ b/DataSourceService/DataSourceService.Application/DataSources/DataSourceAppService.cs
@@ -1,0 +1,31 @@
+namespace DataSourceService.Application.DataSources;
+
+using DataSourceService.Application.DataSources.Dtos;
+using DataSourceService.Application.DataSources.Services;
+
+public class DataSourceAppService : IDynamicApiController
+{
+    private readonly IDataSourceService _service;
+    public DataSourceAppService(IDataSourceService service)
+    {
+        _service = service;
+    }
+
+    public Task<List<DataSourceDto>> GetList(string? typeCode)
+        => _service.GetListAsync(typeCode);
+
+    public Task<DataSourceDto?> Get(string code)
+        => _service.GetAsync(code);
+
+    public Task Create(DataSourceDto dto)
+        => _service.CreateAsync(dto);
+
+    public Task Update(DataSourceDto dto)
+        => _service.UpdateAsync(dto);
+
+    public Task Delete(string code)
+        => _service.DeleteAsync(code);
+
+    public Task<bool> TestConnection(DataSourceDto dto)
+        => _service.TestConnectionAsync(dto);
+}

--- a/DataSourceService/DataSourceService.Application/DataSources/Dtos/DataSourceDto.cs
+++ b/DataSourceService/DataSourceService.Application/DataSources/Dtos/DataSourceDto.cs
@@ -1,0 +1,10 @@
+namespace DataSourceService.Application.DataSources.Dtos;
+
+public class DataSourceDto
+{
+    public string Code { get; set; } = string.Empty;
+    public string TypeCode { get; set; } = string.Empty;
+    public string? Name { get; set; }
+    public string? Config { get; set; }
+    public bool Enabled { get; set; }
+}

--- a/DataSourceService/DataSourceService.Application/DataSources/Services/DataSourceService.cs
+++ b/DataSourceService/DataSourceService.Application/DataSources/Services/DataSourceService.cs
@@ -1,0 +1,57 @@
+namespace DataSourceService.Application.DataSources.Services;
+
+using System.Text.Json;
+using Common.Models;
+using DataSourceService.Application.DataSources.Dtos;
+using DataSourceService.Core.Entities;
+using DataSourceService.Core.Repositories;
+
+public class DataSourceService : IDataSourceService, ITransient
+{
+    private readonly IDataSourceRepo _repo;
+    private readonly DataSourcePluginManager _pluginManager;
+
+    public DataSourceService(IDataSourceRepo repo, DataSourcePluginManager pluginManager)
+    {
+        _repo = repo;
+        _pluginManager = pluginManager;
+    }
+
+    public async Task<List<DataSourceDto>> GetListAsync(string? typeCode)
+    {
+        var list = await _repo.GetListAsync(typeCode);
+        return list.Adapt<List<DataSourceDto>>();
+    }
+
+    public async Task<DataSourceDto?> GetAsync(string code)
+    {
+        var entity = await _repo.GetAsync(code);
+        return entity?.Adapt<DataSourceDto>();
+    }
+
+    public async Task CreateAsync(DataSourceDto dto)
+    {
+        var entity = dto.Adapt<DataSource>();
+        await _repo.InsertAsync(entity);
+    }
+
+    public async Task UpdateAsync(DataSourceDto dto)
+    {
+        var entity = dto.Adapt<DataSource>();
+        await _repo.UpdateAsync(entity);
+    }
+
+    public async Task DeleteAsync(string code)
+    {
+        await _repo.DeleteAsync(code);
+    }
+
+    public async Task<bool> TestConnectionAsync(DataSourceDto dto)
+    {
+        if (string.IsNullOrEmpty(dto.Config)) return false;
+        var config = JsonSerializer.Deserialize<DataSourceConfig>(dto.Config);
+        var adapter = _pluginManager.GetAdapter(dto.TypeCode);
+        if (adapter == null || config == null) return false;
+        return await adapter.TestConnectionAsync(config);
+    }
+}

--- a/DataSourceService/DataSourceService.Application/DataSources/Services/IDataSourceService.cs
+++ b/DataSourceService/DataSourceService.Application/DataSources/Services/IDataSourceService.cs
@@ -1,0 +1,13 @@
+namespace DataSourceService.Application.DataSources.Services;
+
+using DataSourceService.Application.DataSources.Dtos;
+
+public interface IDataSourceService
+{
+    Task<List<DataSourceDto>> GetListAsync(string? typeCode);
+    Task<DataSourceDto?> GetAsync(string code);
+    Task CreateAsync(DataSourceDto dto);
+    Task UpdateAsync(DataSourceDto dto);
+    Task DeleteAsync(string code);
+    Task<bool> TestConnectionAsync(DataSourceDto dto);
+}

--- a/DataSourceService/DataSourceService.Application/Startup.cs
+++ b/DataSourceService/DataSourceService.Application/Startup.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DataSourceService.Application;
+
+public class Startup : AppStartup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+
+    public void Configure(IApplicationBuilder app, DataSourcePluginManager manager)
+    {
+        manager.LoadAll();
+    }
+}

--- a/DataSourceService/DataSourceService.Core/Attributes/IncreTableAttribute.cs
+++ b/DataSourceService/DataSourceService.Core/Attributes/IncreTableAttribute.cs
@@ -1,0 +1,7 @@
+namespace DataSourceService.Core.Attributes;
+
+[System.AttributeUsage(System.AttributeTargets.Class)]
+public sealed class IncreTableAttribute : System.Attribute
+{
+}
+

--- a/DataSourceService/DataSourceService.Core/DbContext.cs
+++ b/DataSourceService/DataSourceService.Core/DbContext.cs
@@ -1,23 +1,82 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using Furion;
+using Microsoft.Extensions.Configuration;
 using SqlSugar;
+using DataSourceService.Core.Attributes;
 
-namespace DataSourceService.Core
+namespace DataSourceService.Core;
+
+/// <summary>
+/// 数据库上下文对象
+/// </summary>
+public static class DbContext
 {
     /// <summary>
-    /// 数据库上下文对象
+    /// SqlSugar 数据库实例
     /// </summary>
-    public static class DbContext
+    public static readonly SqlSugarScope Instance = new(
+        // 读取 appsettings.json 中的 ConnectionConfigs 配置节点
+        App.GetConfig<List<ConnectionConfig>>("ConnectionConfigs"),
+        db =>
+        {
+            // 这里配置全局事件，比如拦截执行 SQL
+        });
+
+    static DbContext()
     {
-        /// <summary>
-        /// SqlSugar 数据库实例
-        /// </summary>
-        public static readonly SqlSugarScope Instance = new(
-            // 读取 appsettings.json 中的 ConnectionConfigs 配置节点
-            App.GetConfig<List<ConnectionConfig>>("ConnectionConfigs")
-            , db =>
+        var config = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("database.json", optional: true)
+            .Build();
+
+        var dbSettings = config.GetSection("DbSettings").Get<DbSettings>() ?? new();
+        var tableSettings = config.GetSection("TableSettings").Get<TableSettings>() ?? new();
+
+        if (dbSettings.EnableInitDb)
+        {
+            foreach (var conn in Instance.Ado.ConnectionConfigList)
             {
-                // 这里配置全局事件，比如拦截执行 SQL
-            });
+                var db = new SqlSugarClient(conn);
+                db.DbMaintenance.CreateDatabase();
+            }
+        }
+
+        var entityTypes = new[]
+        {
+            typeof(Entities.DataSourceType),
+            typeof(Entities.DataSource)
+        };
+
+        if (tableSettings.EnableInitTable)
+        {
+            Instance.CodeFirst.InitTables(entityTypes);
+        }
+        else if (tableSettings.EnableIncreTable)
+        {
+            var increTypes = entityTypes
+                .Where(t => t.IsDefined(typeof(IncreTableAttribute), true))
+                .ToArray();
+            if (increTypes.Length > 0)
+            {
+                Instance.CodeFirst.InitTables(increTypes);
+            }
+        }
+    }
+
+    private class DbSettings
+    {
+        public bool EnableInitDb { get; set; }
+        public bool EnableInitView { get; set; }
+        public bool EnableDiffLog { get; set; }
+        public bool EnableUnderLine { get; set; }
+        public bool EnableConnEncrypt { get; set; }
+    }
+
+    private class TableSettings
+    {
+        public bool EnableInitTable { get; set; }
+        public bool EnableIncreTable { get; set; }
     }
 }
+

--- a/DataSourceService/DataSourceService.Core/Entities/DataSource.cs
+++ b/DataSourceService/DataSourceService.Core/Entities/DataSource.cs
@@ -1,0 +1,16 @@
+namespace DataSourceService.Core.Entities;
+
+using SqlSugar;
+using DataSourceService.Core.Attributes;
+
+[IncreTable]
+[SugarTable("datasources")]
+public class DataSource
+{
+    [SugarColumn(IsPrimaryKey = true)]
+    public string Code { get; set; } = string.Empty;
+    public string TypeCode { get; set; } = string.Empty;
+    public string? Name { get; set; }
+    public string? Config { get; set; }
+    public bool Enabled { get; set; } = true;
+}

--- a/DataSourceService/DataSourceService.Core/Entities/DataSourceType.cs
+++ b/DataSourceService/DataSourceService.Core/Entities/DataSourceType.cs
@@ -1,0 +1,15 @@
+namespace DataSourceService.Core.Entities;
+
+using SqlSugar;
+using DataSourceService.Core.Attributes;
+
+[IncreTable]
+[SugarTable("datasource_types")]
+public class DataSourceType
+{
+    [SugarColumn(IsPrimaryKey = true)]
+    public string Code { get; set; } = string.Empty;
+    public string? Name { get; set; }
+    public string? ConfigSchema { get; set; }
+    public string? PluginAssembly { get; set; }
+}

--- a/DataSourceService/DataSourceService.Core/Repositories/DataSourceRepo.cs
+++ b/DataSourceService/DataSourceService.Core/Repositories/DataSourceRepo.cs
@@ -1,0 +1,38 @@
+namespace DataSourceService.Core.Repositories;
+
+using DataSourceService.Core.Entities;
+using Furion.DependencyInjection;
+using DataSourceService.Core;
+
+public class DataSourceRepo : IDataSourceRepo, ITransient
+{
+    public async Task<List<DataSource>> GetListAsync(string? typeCode)
+    {
+        var query = DbContext.Instance.Queryable<DataSource>();
+        if (!string.IsNullOrEmpty(typeCode))
+        {
+            query = query.Where(x => x.TypeCode == typeCode);
+        }
+        return await query.ToListAsync();
+    }
+
+    public async Task<DataSource?> GetAsync(string code)
+    {
+        return await DbContext.Instance.Queryable<DataSource>().FirstAsync(x => x.Code == code);
+    }
+
+    public async Task InsertAsync(DataSource entity)
+    {
+        await DbContext.Instance.Insertable(entity).ExecuteCommandAsync();
+    }
+
+    public async Task UpdateAsync(DataSource entity)
+    {
+        await DbContext.Instance.Updateable(entity).ExecuteCommandAsync();
+    }
+
+    public async Task DeleteAsync(string code)
+    {
+        await DbContext.Instance.Deleteable<DataSource>().In(code).ExecuteCommandAsync();
+    }
+}

--- a/DataSourceService/DataSourceService.Core/Repositories/DataSourceTypeRepo.cs
+++ b/DataSourceService/DataSourceService.Core/Repositories/DataSourceTypeRepo.cs
@@ -1,0 +1,33 @@
+namespace DataSourceService.Core.Repositories;
+
+using DataSourceService.Core.Entities;
+using Furion.DependencyInjection;
+using DataSourceService.Core;
+
+public class DataSourceTypeRepo : IDataSourceTypeRepo, ITransient
+{
+    public async Task<List<DataSourceType>> GetListAsync()
+    {
+        return await DbContext.Instance.Queryable<DataSourceType>().ToListAsync();
+    }
+
+    public async Task<DataSourceType?> GetAsync(string code)
+    {
+        return await DbContext.Instance.Queryable<DataSourceType>().FirstAsync(x => x.Code == code);
+    }
+
+    public async Task InsertAsync(DataSourceType entity)
+    {
+        await DbContext.Instance.Insertable(entity).ExecuteCommandAsync();
+    }
+
+    public async Task UpdateAsync(DataSourceType entity)
+    {
+        await DbContext.Instance.Updateable(entity).ExecuteCommandAsync();
+    }
+
+    public async Task DeleteAsync(string code)
+    {
+        await DbContext.Instance.Deleteable<DataSourceType>().In(code).ExecuteCommandAsync();
+    }
+}

--- a/DataSourceService/DataSourceService.Core/Repositories/IDataSourceRepo.cs
+++ b/DataSourceService/DataSourceService.Core/Repositories/IDataSourceRepo.cs
@@ -1,0 +1,12 @@
+namespace DataSourceService.Core.Repositories;
+
+using DataSourceService.Core.Entities;
+
+public interface IDataSourceRepo
+{
+    Task<List<DataSource>> GetListAsync(string? typeCode);
+    Task<DataSource?> GetAsync(string code);
+    Task InsertAsync(DataSource entity);
+    Task UpdateAsync(DataSource entity);
+    Task DeleteAsync(string code);
+}

--- a/DataSourceService/DataSourceService.Core/Repositories/IDataSourceTypeRepo.cs
+++ b/DataSourceService/DataSourceService.Core/Repositories/IDataSourceTypeRepo.cs
@@ -1,0 +1,12 @@
+namespace DataSourceService.Core.Repositories;
+
+using DataSourceService.Core.Entities;
+
+public interface IDataSourceTypeRepo
+{
+    Task<List<DataSourceType>> GetListAsync();
+    Task<DataSourceType?> GetAsync(string code);
+    Task InsertAsync(DataSourceType entity);
+    Task UpdateAsync(DataSourceType entity);
+    Task DeleteAsync(string code);
+}

--- a/DataSourceService/DataSourceService.Web.Entry/DataSourceService.Web.Entry.csproj
+++ b/DataSourceService/DataSourceService.Web.Entry/DataSourceService.Web.Entry.csproj
@@ -8,9 +8,14 @@
 		<PublishReadyToRunComposite>true</PublishReadyToRunComposite>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\DataSourceService.Web.Core\DataSourceService.Web.Core.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DataSourceService.Web.Core\DataSourceService.Web.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\database.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 	<ProjectExtensions>
 		<VisualStudio>
 			<UserProperties properties_4launchsettings_1json__JsonSchema="" />

--- a/DataSourceService/DataSourceService.sln
+++ b/DataSourceService/DataSourceService.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataSourceService.Core", "D
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataSourceService.Web.Entry", "DataSourceService.Web.Entry\DataSourceService.Web.Entry.csproj", "{C8D99F52-EDC7-411F-8300-6DB14BF59E8C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "..\Common\Common.csproj", "{F44915BB-FA80-4865-ADAB-10DACE40E756}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{C8D99F52-EDC7-411F-8300-6DB14BF59E8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8D99F52-EDC7-411F-8300-6DB14BF59E8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8D99F52-EDC7-411F-8300-6DB14BF59E8C}.Release|Any CPU.Build.0 = Release|Any CPU
+                {F44915BB-FA80-4865-ADAB-10DACE40E756}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F44915BB-FA80-4865-ADAB-10DACE40E756}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F44915BB-FA80-4865-ADAB-10DACE40E756}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F44915BB-FA80-4865-ADAB-10DACE40E756}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DataSourceService/database.json
+++ b/DataSourceService/database.json
@@ -1,0 +1,14 @@
+{
+  "DbSettings": {
+    "EnableInitDb": false,
+    "EnableInitView": false,
+    "EnableDiffLog": false,
+    "EnableUnderLine": false,
+    "EnableConnEncrypt": false
+  },
+  "TableSettings": {
+    "EnableInitTable": false,
+    "EnableIncreTable": false
+  }
+}
+


### PR DESCRIPTION
## Summary
- add common plugin interfaces and models
- implement data source type and instance entities, repositories, services and dynamic APIs
- introduce plugin manager for loading datasource adapters
- add database initialization settings controlled by `database.json`

## Testing
- `dotnet build DataSourceService/DataSourceService.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c52c37d0832ea93c9553a7c1eae9